### PR TITLE
Update dAmn token fetch for CSRF login

### DIFF
--- a/Kevin/Util/Token.hs
+++ b/Kevin/Util/Token.hs
@@ -24,34 +24,51 @@ recvUntil ctx str = do line <- recvData ctx
 concatHeaders :: [(String,String)] -> String
 concatHeaders = intercalate "\r\n" . map (\(x,y) -> x ++ ": " ++ y)
 
+scrapeFormValue :: String -> B.ByteString -> B.ByteString
+scrapeFormValue key bs = B.takeWhile (/='"') . B.drop 7 . head
+                       . filter (\l -> "value=" `B.isPrefixOf` l) . B.words . head
+                       . filter (\l -> B.pack key `B.isInfixOf` l) . B.lines $ bs
+
+scrapeCookies :: B.ByteString -> B.ByteString
+scrapeCookies bs = B.intercalate ";" . map snd
+                 . filter ((== "Set-Cookie") . fst)
+                 . map (second (B.drop 2 . B.takeWhile (/=';'))
+                       . B.breakSubstring ": ")
+                 . B.lines $ bs
+
 getToken :: T.Text -> T.Text -> IO (Maybe T.Text)
 getToken uname pass = do let params = defaultParams { pCiphers = ciphersuite_all
                                                     , onCertificatesRecv = certificateChecks [return . certificateVerifyDomain "chat.deviantart.com"] }
                              headers :: [(String, String)]
                              headers = [("Connection", "closed"), ("Content-Type", "application/x-www-form-urlencoded")]
                          gen <- makeSystem
-                         ctx <- connectionClient "www.deviantart.com" "443" params gen
+                         ctv <- connectionClient "www.deviantart.com" "443" params gen
+                         handshake ctv
+                         sendData ctv . LB.pack $ "GET /users/login HTTP/1.1\r\nHost: www.deviantart.com\r\n\r\n"
+                         bl <- recvUntil ctv "validate_key"
+                         bye ctv
+
                          let payload = urlEncodeVars [ ("username", T.unpack uname)
                                                      , ("password", T.unpack pass)
+                                                     , ("validate_token", B.unpack (scrapeFormValue "validate_token" bl))
+                                                     , ("validate_key", B.unpack (scrapeFormValue "validate_key" bl))
                                                      , ("remember_me","1")
                                                      ]
+                         ctx <- connectionClient "www.deviantart.com" "443" params gen
                          handshake ctx
-                         sendData ctx . LB.pack $ printf "POST /users/login HTTP/1.1\r\n%s\r\nContent-Length: %d\r\n\r\n%s"
+                         sendData ctx . LB.pack $ printf "POST /users/login HTTP/1.1\r\n%s\r\n\
+                                                         \cookie: %s\r\nContent-Length: %d\r\n\r\n%s"
                                                          (concatHeaders $ ("Host", "www.deviantart.com"):headers)
+                                                         (B.unpack (scrapeCookies bl))
                                                          (length payload)
                                                          payload
                          bs <- recvData ctx
                          if "wrong-password" `B.isInfixOf` bs
                             then return Nothing
-                            else do let cookie = B.intercalate ";" . map snd
-                                               . filter ((== "Set-Cookie") . fst)
-                                               . map (second (B.drop 2 . B.takeWhile (/=';'))
-                                                    . B.breakSubstring ": ")
-                                               . B.lines $ bs
-                                        s = printf "GET /chat/Botdom HTTP/1.1\r\n%s\r\n\
+                            else do let s = printf "GET /chat/Botdom HTTP/1.1\r\n%s\r\n\
                                                 \cookie: %s\r\n\r\n"
                                                 (concatHeaders [("Host", "chat.deviantart.com")])
-                                                (B.unpack cookie)
+                                                (B.unpack (scrapeCookies bs))
                                     sendData ctx $ LB.pack s
                                     bq <- recvUntil ctx "dAmnChat_Init"
                                     return . (Just . decodeUtf8 . B.take 32 . B.tail


### PR DESCRIPTION
With dA's new requirement for passing validation tokens through at login time, a three-stage process is needed to fetch the dAmn token: load and scrape the login page, log in, load up a dAmn page.

The code is probably non-ideal, since I don't actually know Haskell, but it appears to work.
